### PR TITLE
Soporte para mongodb de forma remota (Atlas)

### DIFF
--- a/microservice-config/src/main/resources/configurations/msvc-logs.yml
+++ b/microservice-config/src/main/resources/configurations/msvc-logs.yml
@@ -1,6 +1,14 @@
 server:
   port: 8095
 
+## mongodb de forma remota ##
+#spring:
+#  data:
+#    mongodb:
+#      uri: mongodb+srv://<user>:<db_password>@cluster0.5gauqjk.mongodb.net/?retryWrites=true&w=majority&appName=Cluster0
+#      database: DB
+
+# mongodb de forma local
 spring:
   data:
     mongodb:


### PR DESCRIPTION
PR donde se implementa un ejemplo de como se tiene que conectar el microservicios de logs con un cluster en la nube de Atlas....